### PR TITLE
Adding redirect on invalid JWT using the redirect_uri_invalid_jwk option

### DIFF
--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -271,6 +271,10 @@ func newSignerEndpointCfg(alg, ID, URL string) *config.EndpointConfig {
 }
 
 func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointConfig {
+	return newVerifierEndpointCfgWithRedirect(alg, URL, roles, "")
+}
+
+func newVerifierEndpointCfgWithRedirect(alg, URL string, roles []string, redirectUri string) *config.EndpointConfig {
 	return &config.EndpointConfig{
 		Timeout:  time.Second,
 		Endpoint: "/private",
@@ -283,14 +287,15 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 		},
 		ExtraConfig: config.ExtraConfig{
 			krakendjose.ValidatorNamespace: map[string]interface{}{
-				"alg":                  alg,
-				"jwk-url":              URL,
-				"audience":             []string{"http://api.example.com"},
-				"issuer":               "http://example.com",
-				"roles":                roles,
-				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
-				"disable_jwk_security": true,
-				"cache":                true,
+				"alg":                      alg,
+				"jwk-url":                  URL,
+				"audience":                 []string{"http://api.example.com"},
+				"issuer":                   "http://example.com",
+				"roles":                    roles,
+				"propagate-claims":         [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
+				"disable_jwk_security":     true,
+				"cache":                    true,
+				"redirect_uri_invalid_jwk": redirectUri,
 			},
 		},
 	}

--- a/jws.go
+++ b/jws.go
@@ -36,6 +36,7 @@ type SignatureConfig struct {
 	LocalPath               string     `json:"jwk_local_path,omitempty"`
 	SecretURL               string     `json:"secret_url,omitempty"`
 	CipherKey               []byte     `json:"cypher_key,omitempty"`
+	RedirectUri             string     `json:"redirect_uri_invalid_jwk,omitempty"`
 }
 
 type SignerConfig struct {

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -250,6 +250,10 @@ func newSignerEndpointCfg(alg, ID, URL string) *config.EndpointConfig {
 }
 
 func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointConfig {
+	return newVerifierEndpointCfgWithRedirect(alg, URL, roles, "")
+}
+
+func newVerifierEndpointCfgWithRedirect(alg, URL string, roles []string, redirectUri string) *config.EndpointConfig {
 	return &config.EndpointConfig{
 		Timeout:  time.Second,
 		Endpoint: "/private",
@@ -263,14 +267,15 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 		},
 		ExtraConfig: config.ExtraConfig{
 			krakendjose.ValidatorNamespace: map[string]interface{}{
-				"alg":                  alg,
-				"jwk-url":              URL,
-				"audience":             []string{"http://api.example.com"},
-				"issuer":               "http://example.com",
-				"roles":                roles,
-				"propagate-claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
-				"disable_jwk_security": true,
-				"cache":                true,
+				"alg":                  		alg,
+				"jwk-url":              		URL,
+				"audience":             		[]string{"http://api.example.com"},
+				"issuer":               		"http://example.com",
+				"roles":                		roles,
+				"propagate-claims":     		[][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}},
+				"disable_jwk_security": 		true,
+				"cache":                		true,
+				"redirect_uri_invalid_jwk":     redirectUri,
 			},
 		},
 	}


### PR DESCRIPTION
If the JWT token is invalid Krakend returns 401. 

There are use-cases when a redirect might be necessary to point the client to an alternative service or login board 