### PR TITLE
jwk_local_path with cache

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -61,6 +61,9 @@ func SecretProvider(cfg SecretProviderConfig, te auth0.RequestTokenExtractor) (*
 		return newLocalSecretProvider(opts, cfg, te)
 	}
 
+	if cfg.LocalPath != "" {
+		return nil, fmt.Errorf("cache could not be used with jwk_local_path")
+	}
 	var cacheDuration time.Duration
 	cacheDuration = time.Duration(cfg.CacheDuration) * time.Second
 	// Set default duration to 15 minute


### PR DESCRIPTION
**Why**: When using the `jwk_local_path` parameter with `cache` enabled, unexpected behavior occurs: jose tries to use an empty jwk_url variable. Еhere is no error or warning in the logs, which makes it quite difficult to understand source of the problem