### PR TITLE
Add a global cache layer common for all the endpoints

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -78,7 +78,7 @@ func SecretProvider(cfg SecretProviderConfig, te auth0.RequestTokenExtractor) (*
 	client := NewJWKClientWithCache(
 		opts,
 		te,
-		NewMemoryKeyCacher(cacheDuration, auth0.MaxCacheSizeNoCheck, opts.KeyIdentifyStrategy),
+		NewGlobalMemoryKeyCacher(cacheDuration, auth0.MaxCacheSizeNoCheck, opts.KeyIdentifyStrategy),
 	)
 
 	// request an unexistent key in order to cache all the actual ones

--- a/jwk_client_test.go
+++ b/jwk_client_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/luraproject/lura/v2/logging"
 )
 
-func TestJWKClient_cache(t *testing.T) {
-	jwk1 := []byte(`{ "keys": [{
+func TestJWKClient_globalCache(t *testing.T) {
+	jwk := []byte(`{ "keys": [{
 		"kty": "RSA",
 		"e": "AQAB",
 		"use": "sig",
@@ -26,7 +26,7 @@ func TestJWKClient_cache(t *testing.T) {
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		atomic.AddUint64(&count, 1)
-		w.Write(jwk1)
+		w.Write(jwk)
 	}))
 
 	defer backend.Close()
@@ -60,6 +60,7 @@ func TestJWKClient_cache(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("invalid count %d", count)
+		return
 	}
 	<-time.After(4 * time.Second)
 	for i := 0; i < 10; i++ {

--- a/jwk_client_test.go
+++ b/jwk_client_test.go
@@ -1,0 +1,79 @@
+package jose
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/auth0-community/go-auth0"
+	"github.com/luraproject/lura/v2/config"
+	"github.com/luraproject/lura/v2/logging"
+)
+
+func TestJWKClient_cache(t *testing.T) {
+	jwk1 := []byte(`{ "keys": [{
+		"kty": "RSA",
+		"e": "AQAB",
+		"use": "sig",
+		"kid": "8-2-2PBmlHKMo5tizxp-uw9pFrQQamfa1M1ZYMrAFZI",
+		"alg": "RS256",
+		"n": "n6p2fLU7PLwMvJ-xeukn-f5wrAdyZ0ZaFa6kanQzVBofacLs2l4FVe6_bcjw4VGWM2Ct3WgelZQUYVkFbqePODpMnV0lV8U4hxbIpMEJOJqY3tK48_PBIdEkl02DN8LaucK1Y7GpOlUZFrWAOM68TyWJTjkyc-yx0ibu2MFaGQoXacV7239Yei_x68iGBpQa2f9SYv8U5nJINdI1CuyccQp991qeskJATgn-UVqQfOfHDsUA2qud2yNOf5QKkvqqPEH_IXuTtPcf_yzVuco9rhhUW8q5bC4R0BxjCv9w4b-Q_UKjKEXQK5UlAuiWqWgmQbQO9Ne94EDFpjlkCtil2Q"
+	}]}`)
+
+	var count uint64
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		atomic.AddUint64(&count, 1)
+		w.Write(jwk1)
+	}))
+
+	defer backend.Close()
+	opts := JWKClientOptions{
+		JWKClientOptions: auth0.JWKClientOptions{
+			URI: backend.URL,
+		},
+	}
+	te := auth0.FromMultiple(
+		auth0.RequestTokenExtractorFunc(auth0.FromHeader),
+	)
+	cfg := config.ExtraConfig{
+		ValidatorNamespace: map[string]interface{}{
+			"cache_duration": "3s",
+		},
+	}
+	if err := SetGlobalCacher(logging.NoOp, cfg); err != nil {
+		t.Error(err)
+		return
+	}
+	for i := 0; i < 10; i++ {
+		client := NewJWKClientWithCache(
+			opts,
+			te,
+			NewGlobalMemoryKeyCacher(1*time.Second, auth0.MaxCacheSizeNoCheck, opts.KeyIdentifyStrategy),
+		)
+		if _, err := client.GetKey("8-2-2PBmlHKMo5tizxp-uw9pFrQQamfa1M1ZYMrAFZI"); err != nil {
+			t.Error(err)
+			return
+		}
+	}
+	if count != 1 {
+		t.Errorf("invalid count %d", count)
+	}
+	<-time.After(4 * time.Second)
+	for i := 0; i < 10; i++ {
+		client := NewJWKClientWithCache(
+			opts,
+			te,
+			NewGlobalMemoryKeyCacher(1*time.Second, auth0.MaxCacheSizeNoCheck, opts.KeyIdentifyStrategy),
+		)
+		if _, err := client.GetKey("8-2-2PBmlHKMo5tizxp-uw9pFrQQamfa1M1ZYMrAFZI"); err != nil {
+			t.Error(err)
+			return
+		}
+	}
+	if count != 2 {
+		t.Errorf("invalid count %d", count)
+	}
+}

--- a/jwk_client_test.go
+++ b/jwk_client_test.go
@@ -40,7 +40,7 @@ func TestJWKClient_globalCache(t *testing.T) {
 	)
 	cfg := config.ExtraConfig{
 		ValidatorNamespace: map[string]interface{}{
-			"cache_duration": "3s",
+			"shared_cache_duration": 3,
 		},
 	}
 	if err := SetGlobalCacher(logging.NoOp, cfg); err != nil {

--- a/key_cacher.go
+++ b/key_cacher.go
@@ -137,7 +137,6 @@ type GMemoryKeyCacher struct {
 }
 
 func (gkc *GMemoryKeyCacher) Add(keyID string, downloadedKeys []jose.JSONWebKey) (*jose.JSONWebKey, error) {
-
 	if gkc.Global.kc != nil {
 		gkc.Global.mu.Lock()
 		gkc.Global.kc.Add(keyID, downloadedKeys)

--- a/key_cacher.go
+++ b/key_cacher.go
@@ -166,7 +166,8 @@ func NewGlobalMemoryKeyCacher(maxKeyAge time.Duration, maxCacheSize int, keyIden
 		keyIdentifyStrategy = "kid"
 	}
 	return &GMemoryKeyCacher{
-		MemoryKeyCacher: &MemoryKeyCacher{entries: map[string]keyCacherEntry{},
+		MemoryKeyCacher: &MemoryKeyCacher{
+			entries:      map[string]keyCacherEntry{},
 			maxKeyAge:    maxKeyAge,
 			maxCacheSize: maxCacheSize,
 			keyIDGetter:  KeyIDGetterFactory(keyIdentifyStrategy),

--- a/key_cacher.go
+++ b/key_cacher.go
@@ -68,7 +68,7 @@ func configGetter(l logging.Logger, cfg config.ExtraConfig) (serviceConfig, erro
 	}
 	if scfg.CacheDuration == 0 {
 		scfg.CacheDuration = defaultGlobalCacheMaxAge
-		l.Error("[SERVICE: JOSE] Empty shared_cache_duration, using default (15m)")
+		l.Info("[SERVICE: JOSE] Empty shared_cache_duration, using default (15m)")
 	}
 	return scfg, nil
 }


### PR DESCRIPTION
 to reduce pressure on the JWK backends.