### PR TITLE
Added optional token validation

### DIFF
--- a/gin/jose.go
+++ b/gin/jose.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	auth0 "github.com/auth0-community/go-auth0"
+	"github.com/auth0-community/go-auth0"
 	"github.com/gin-gonic/gin"
 	krakendjose "github.com/krakendio/krakend-jose/v2"
 	"github.com/luraproject/lura/v2/config"
@@ -129,6 +129,10 @@ func TokenSignatureValidator(hf ginlura.HandlerFactory, logger logging.Logger, r
 		return func(c *gin.Context) {
 			token, err := validator.ValidateRequest(c.Request)
 			if err != nil {
+				if scfg.Optional && err == auth0.ErrTokenNotFound {
+					handler(c)
+					return
+				}
 				if scfg.OperationDebug {
 					logger.Error(logPrefix, "Unable to validate the token:", err.Error())
 				}

--- a/gin/jose_example_test.go
+++ b/gin/jose_example_test.go
@@ -24,7 +24,7 @@ func Example_RS256() {
 	publicServer := httptest.NewServer(jwkEndpoint("public"))
 	defer publicServer.Close()
 
-	verifierCfg := newVerifierEndpointCfg("RS256", publicServer.URL, []string{"role_a"})
+	verifierCfg := newVerifierEndpointCfg("RS256", publicServer.URL, []string{"role_a"}, false)
 	verifierCfg.ExtraConfig[krakendjose.ValidatorNamespace].(map[string]interface{})["operation_debug"] = true
 
 	runValidationCycle(
@@ -72,7 +72,7 @@ func Example_HS256() {
 
 	runValidationCycle(
 		newSignerEndpointCfg("HS256", "sim2", server.URL),
-		newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}),
+		newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}, false),
 	)
 
 	// output:
@@ -114,7 +114,7 @@ func Example_HS256_cookie() {
 
 	sCfg := newSignerEndpointCfg("HS256", "sim2", server.URL)
 	_, signer, _ := krakendjose.NewSigner(sCfg, nil)
-	verifierCfg := newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"})
+	verifierCfg := newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}, false)
 
 	externalTokenIssuer := func(rw http.ResponseWriter, req *http.Request) {
 		resp, _ := tokenIssuer(context.Background(), new(proxy.Request))
@@ -313,7 +313,7 @@ func newSignerEndpointCfg(alg, ID, URL string) *config.EndpointConfig {
 	}
 }
 
-func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointConfig {
+func newVerifierEndpointCfg(alg, URL string, roles []string, optional bool) *config.EndpointConfig {
 	return &config.EndpointConfig{
 		Timeout:  time.Second,
 		Endpoint: "/private",
@@ -334,6 +334,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"propagate_claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}, {"sub", "x-krakend-replace"}},
 				"disable_jwk_security": true,
 				"cache":                true,
+				"optional":             optional,
 			},
 		},
 	}

--- a/gin/jose_test.go
+++ b/gin/jose_test.go
@@ -21,19 +21,23 @@ func TestTokenSignatureValidator(t *testing.T) {
 	server := httptest.NewServer(jwkEndpoint("public"))
 	defer server.Close()
 
-	validatorEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_a"})
+	validatorEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_a"}, false)
 
-	forbidenEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_c"})
+	forbidenEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_c"}, false)
 	forbidenEndpointCfg.Endpoint = "/forbiden"
 
-	registeredEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	registeredEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, false)
 	registeredEndpointCfg.Endpoint = "/registered"
 	registeredEndpointCfg.Backend[0].URLPattern = "/{{.JWT.sub}}/{{.JWT.jti}}?foo={{.JWT.iss}}"
 
-	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, false)
 	propagateHeadersEndpointCfg.Endpoint = "/propagateheaders"
 
+	optionalEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, true)
+	optionalEndpointCfg.Endpoint = "/optional"
+
 	token := "eyJhbGciOiJSUzI1NiIsImtpZCI6IjIwMTEtMDQtMjkifQ.eyJhdWQiOiJodHRwOi8vYXBpLmV4YW1wbGUuY29tIiwiZXhwIjoxNzM1Njg5NjAwLCJpc3MiOiJodHRwOi8vZXhhbXBsZS5jb20iLCJqdGkiOiJtbmIyM3Zjc3J0NzU2eXVpb21uYnZjeDk4ZXJ0eXVpb3AiLCJyb2xlcyI6WyJyb2xlX2EiLCJyb2xlX2IiXSwic3ViIjoiMTIzNDU2Nzg5MHF3ZXJ0eXVpbyJ9.NrLwxZK8UhS6CV2ijdJLUfAinpjBn5_uliZCdzQ7v-Dc8lcv1AQA9cYsG63RseKWH9u6-TqPKMZQ56WfhqL028BLDdQCiaeuBoLzYU1tQLakA1V0YmouuEVixWLzueVaQhyGx-iKuiuFhzHWZSqFqSehiyzI9fb5O6Gcc2L6rMEoxQMaJomVS93h-t013MNq3ADLWTXRaO-negydqax_WmzlVWp_RDroR0s5J2L2klgmBXVwh6SYy5vg7RrnuN3S8g4oSicJIi9NgnG-dDikuaOg2DeFUt-mYq_j_PbNXf9TUl5hl4kEy7E0JauJ17d1BUuTl3ChY4BOmhQYRN0dYg"
+	invalidToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
 	dummyProxy := func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
 		return &proxy.Response{
@@ -85,31 +89,7 @@ func TestTokenSignatureValidator(t *testing.T) {
 	engine.GET(forbidenEndpointCfg.Endpoint, hf(forbidenEndpointCfg, dummyProxy))
 	engine.GET(registeredEndpointCfg.Endpoint, hf(registeredEndpointCfg, assertProxy))
 	engine.GET(propagateHeadersEndpointCfg.Endpoint, hf(propagateHeadersEndpointCfg, dummyProxy))
-
-	req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
-
-	w := httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "" {
-		t.Errorf("unexpected body: %s", body)
-	}
-
-	req = httptest.NewRequest("GET", validatorEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
-
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}" {
-		t.Errorf("unexpected body: %s", body)
-	}
+	engine.GET(optionalEndpointCfg.Endpoint, hf(optionalEndpointCfg, dummyProxy))
 
 	if log := buf.String(); !strings.Contains(log, "DEBUG: [ENDPOINT: /propagateheaders][JWTSigner] Signer disabled") {
 		t.Error(log)
@@ -117,69 +97,94 @@ func TestTokenSignatureValidator(t *testing.T) {
 		return
 	}
 
-	req = httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
+	t.Run("unathorized without token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
 
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "" {
-		t.Errorf("unexpected body: %s", body)
-	}
+		assertStatus(t, w.Code, http.StatusUnauthorized)
+		assertBody(t, w.Body.String(), "")
+	})
 
-	req = httptest.NewRequest("GET", registeredEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
+	t.Run("ok with correct token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", validatorEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
 
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}" {
-		t.Errorf("unexpected body: %s", body)
-	}
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}")
+	})
 
-	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
-	// Check header-overwrite: it must be overwritten by a claim in the JWT!
-	req.Header.Set("x-krakend-replace", "abc")
+	t.Run("forbidden with incorrect roles", func(t *testing.T) {
+		req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
 
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
 
-	if req.Header.Get("x-krakend-jti") == "" {
-		t.Error("JWT claim not propagated to header: jti")
-	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
-		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
-	}
+		assertStatus(t, w.Code, http.StatusForbidden)
+		assertBody(t, w.Body.String(), "")
+	})
 
-	// Check that existing header values are overwritten
-	if req.Header.Get("x-krakend-replace") == "abc" {
-		t.Error("JWT claim not propagated to x-krakend-replace header: sub")
-	} else if req.Header.Get("x-krakend-replace") != "1234567890qwertyuio" {
-		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-replace"))
-	}
+	t.Run("ok with param extractor", func(t *testing.T) {
+		req := httptest.NewRequest("GET", registeredEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
 
-	if req.Header.Get("x-krakend-sub") == "" {
-		t.Error("JWT claim not propagated to header: sub")
-	} else if req.Header.Get("x-krakend-sub") != "1234567890qwertyuio" {
-		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-sub"))
-	}
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
 
-	if req.Header.Get("x-krakend-ne") != "" {
-		t.Error("JWT claim propagated, although it shouldn't: nonexistent")
-	}
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}")
+	})
 
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}" {
-		t.Errorf("unexpected body: %s", body)
-	}
+	t.Run("ok with propagate headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+		// Check header-overwrite: it must be overwritten by a claim in the JWT!
+		req.Header.Set("x-krakend-replace", "abc")
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}")
+		assertPropagationHeaders(t, req)
+	})
+
+	t.Run("ok without token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}")
+	})
+
+	t.Run("unauthorized with invalid token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+invalidToken)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusUnauthorized)
+		assertBody(t, w.Body.String(), "")
+	})
+
+	t.Run("ok with valid token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), "{\"aaaa\":{\"bar\":\"b\",\"foo\":\"a\"},\"bbbb\":true,\"cccc\":1234567890}")
+	})
 }
 
 func TestTokenSigner_error(t *testing.T) {
@@ -238,5 +243,46 @@ func jwkEndpoint(name string) http.HandlerFunc {
 		}
 		rw.Header().Set("Content-Type", "application/json")
 		rw.Write(data)
+	}
+}
+
+func assertStatus(t testing.TB, got, want int) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("unexpected status code: %d", got)
+	}
+}
+
+func assertBody(t testing.TB, got, want string) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("unexpected body: %s", got)
+	}
+}
+
+func assertPropagationHeaders(t testing.TB, req *http.Request) {
+	if req.Header.Get("x-krakend-jti") == "" {
+		t.Error("JWT claim not propagated to header: jti")
+	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
+		t.Errorf("wrong JWT claim propagated for 'jti': %v", req.Header.Get("x-krakend-jti"))
+	}
+
+	// Check that existing header values are overwritten
+	if req.Header.Get("x-krakend-replace") == "abc" {
+		t.Error("JWT claim not propagated to x-krakend-replace header: sub")
+	} else if req.Header.Get("x-krakend-replace") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-replace"))
+	}
+
+	if req.Header.Get("x-krakend-sub") == "" {
+		t.Error("JWT claim not propagated to header: sub")
+	} else if req.Header.Get("x-krakend-sub") != "1234567890qwertyuio" {
+		t.Errorf("wrong JWT claim propagated for 'sub': %v", req.Header.Get("x-krakend-sub"))
+	}
+
+	if req.Header.Get("x-krakend-ne") != "" {
+		t.Error("JWT claim propagated, although it shouldn't: nonexistent")
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,7 @@ github.com/Azure/azure-amqp-common-go/v3 v3.2.3/go.mod h1:7rPmbSfszeovxGfc5fSAXE
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v63.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v65.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v66.0.0+incompatible h1:bmmC38SlE8/E81nNADlgmVGurPWMHDX2YNXVQMrBpEE=
 github.com/Azure/azure-sdk-for-go v66.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.1.1/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
@@ -580,6 +581,7 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8n
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=
@@ -770,6 +772,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.78.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
 github.com/digitalocean/godo v1.88.0/go.mod h1:NRpFznZFvhHjBoqZAaOD3khVzsJ3EibzKqFL4R60dmA=
+github.com/dimfeld/httptreemux/v5 v5.3.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -858,6 +861,7 @@ github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ
 github.com/gin-gonic/gin v1.8.2 h1:UzKToD9/PoFj/V4rvlKqTRKnQYyz8Sc1MJlv4JHPtvY=
 github.com/gin-gonic/gin v1.8.2/go.mod h1:qw5AYuDrzRTnhvusDsrov+fDIxp9Dleuu12h8nfB398=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-chi/chi/v5 v5.0.4/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -921,6 +925,7 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-playground/validator/v10 v10.9.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
 github.com/go-playground/validator/v10 v10.11.1 h1:prmOlTVv+YjZjmRmNSF3VmspqJIxJWXmqUsHwfTRRkQ=
 github.com/go-playground/validator/v10 v10.11.1/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
@@ -983,6 +988,7 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -1582,6 +1588,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
@@ -1777,14 +1784,18 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/tv42/httpunix v0.0.0-20191220191345-2ba4b9c3382c/go.mod h1:hzIxponao9Kjc7aWznkXaL4U4TWaDSs8zcsY4Ka08nM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
+github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+github.com/ugorji/go/codec v1.2.6/go.mod h1:V6TCNZ4PHqoHGFZuSG1W8nrCzzdgA2DozYxWFFpvxTw=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/negroni/v2 v2.0.2/go.mod h1:SjdApKzYrObukpN/NnlejbQiZWIUjfDFzQltScGYigI=
 github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
 github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -2254,6 +2265,7 @@ golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/jws.go
+++ b/jws.go
@@ -41,6 +41,7 @@ type SignatureConfig struct {
 	ScopesMatcher           string     `json:"scopes_matcher,omitempty"`
 	KeyIdentifyStrategy     string     `json:"key_identify_strategy"`
 	OperationDebug          bool       `json:"operation_debug,omitempty"`
+	Optional                bool       `json:"optional,omitempty"`
 }
 
 type SignerConfig struct {

--- a/mux/jose.go
+++ b/mux/jose.go
@@ -139,6 +139,10 @@ func TokenSignatureValidator(hf muxlura.HandlerFactory, logger logging.Logger, r
 		return func(w http.ResponseWriter, r *http.Request) {
 			token, err := validator.ValidateRequest(r)
 			if err != nil {
+				if signatureConfig.Optional && err == auth0.ErrTokenNotFound {
+					handler(w, r)
+					return
+				}
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}

--- a/mux/jose_example_test.go
+++ b/mux/jose_example_test.go
@@ -25,7 +25,7 @@ func Example_RS256() {
 
 	runValidationCycle(
 		newSignerEndpointCfg("RS256", "2011-04-29", privateServer.URL),
-		newVerifierEndpointCfg("RS256", publicServer.URL, []string{"role_a"}),
+		newVerifierEndpointCfg("RS256", publicServer.URL, []string{"role_a"}, false),
 	)
 
 	// output:
@@ -51,7 +51,7 @@ func Example_HS256() {
 
 	runValidationCycle(
 		newSignerEndpointCfg("HS256", "sim2", server.URL),
-		newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}),
+		newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}, false),
 	)
 
 	// output:
@@ -77,7 +77,7 @@ func Example_HS256_cookie() {
 
 	sCfg := newSignerEndpointCfg("HS256", "sim2", server.URL)
 	_, signer, _ := krakendjose.NewSigner(sCfg, nil)
-	verifierCfg := newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"})
+	verifierCfg := newVerifierEndpointCfg("HS256", server.URL, []string{"role_a"}, false)
 
 	externalTokenIssuer := func(rw http.ResponseWriter, req *http.Request) {
 		resp, _ := tokenIssuer(context.Background(), new(proxy.Request))
@@ -249,7 +249,7 @@ func newSignerEndpointCfg(alg, ID, URL string) *config.EndpointConfig {
 	}
 }
 
-func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointConfig {
+func newVerifierEndpointCfg(alg, URL string, roles []string, optional bool) *config.EndpointConfig {
 	return &config.EndpointConfig{
 		Timeout:  time.Second,
 		Endpoint: "/private",
@@ -271,6 +271,7 @@ func newVerifierEndpointCfg(alg, URL string, roles []string) *config.EndpointCon
 				"propagate_claims":     [][]string{{"jti", "x-krakend-jti"}, {"sub", "x-krakend-sub"}, {"nonexistent", "x-krakend-ne"}, {"sub", "x-krakend-replace"}},
 				"disable_jwk_security": true,
 				"cache":                true,
+				"optional":             optional,
 			},
 		},
 	}

--- a/mux/jose_test.go
+++ b/mux/jose_test.go
@@ -18,18 +18,22 @@ func TestTokenSignatureValidator(t *testing.T) {
 	server := httptest.NewServer(jwkEndpoint("public"))
 	defer server.Close()
 
-	validatorEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_a"})
+	validatorEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_a"}, false)
 
-	forbidenEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_c"})
+	forbidenEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{"role_c"}, false)
 	forbidenEndpointCfg.Endpoint = "/forbiden"
 
-	registeredEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	registeredEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, false)
 	registeredEndpointCfg.Endpoint = "/registered"
 
-	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{})
+	propagateHeadersEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, false)
 	propagateHeadersEndpointCfg.Endpoint = "/propagateheaders"
 
+	optionalEndpointCfg := newVerifierEndpointCfg("RS256", server.URL, []string{}, true)
+	optionalEndpointCfg.Endpoint = "/optional"
+
 	token := "eyJhbGciOiJSUzI1NiIsImtpZCI6IjIwMTEtMDQtMjkifQ.eyJhdWQiOiJodHRwOi8vYXBpLmV4YW1wbGUuY29tIiwiZXhwIjoxNzM1Njg5NjAwLCJpc3MiOiJodHRwOi8vZXhhbXBsZS5jb20iLCJqdGkiOiJtbmIyM3Zjc3J0NzU2eXVpb21uYnZjeDk4ZXJ0eXVpb3AiLCJyb2xlcyI6WyJyb2xlX2EiLCJyb2xlX2IiXSwic3ViIjoiMTIzNDU2Nzg5MHF3ZXJ0eXVpbyJ9.NrLwxZK8UhS6CV2ijdJLUfAinpjBn5_uliZCdzQ7v-Dc8lcv1AQA9cYsG63RseKWH9u6-TqPKMZQ56WfhqL028BLDdQCiaeuBoLzYU1tQLakA1V0YmouuEVixWLzueVaQhyGx-iKuiuFhzHWZSqFqSehiyzI9fb5O6Gcc2L6rMEoxQMaJomVS93h-t013MNq3ADLWTXRaO-negydqax_WmzlVWp_RDroR0s5J2L2klgmBXVwh6SYy5vg7RrnuN3S8g4oSicJIi9NgnG-dDikuaOg2DeFUt-mYq_j_PbNXf9TUl5hl4kEy7E0JauJ17d1BUuTl3ChY4BOmhQYRN0dYg"
+	invalidToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
 	dummyProxy := func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
 		return &proxy.Response{
@@ -58,70 +62,135 @@ func TestTokenSignatureValidator(t *testing.T) {
 	engine.Handle(forbidenEndpointCfg.Endpoint, "GET", hf(forbidenEndpointCfg, dummyProxy))
 	engine.Handle(registeredEndpointCfg.Endpoint, "GET", hf(registeredEndpointCfg, dummyProxy))
 	engine.Handle(propagateHeadersEndpointCfg.Endpoint, "GET", hf(propagateHeadersEndpointCfg, dummyProxy))
-
-	req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
-
-	w := httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != "Token not found\n" {
-		t.Errorf("unexpected body: '%s'", body)
-	}
-
-	req = httptest.NewRequest("GET", validatorEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
-
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	if w.Code != 200 {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}` {
-		t.Errorf("unexpected body: %s", body)
-	}
+	engine.Handle(optionalEndpointCfg.Endpoint, "GET", hf(optionalEndpointCfg, dummyProxy))
 
 	if log := buf.String(); !strings.Contains(log, "INFO: JOSE: signer disabled for the endpoint /private") {
 		t.Error(log)
 	}
 
-	req = httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
+	t.Run("unathorized without token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
 
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("unexpected status code: %d", w.Code)
+		assertStatus(t, w.Code, http.StatusUnauthorized)
+		assertBody(t, w.Body.String(), "Token not found\n")
+	})
+
+	t.Run("ok with correct token", func(t *testing.T) {
+		req := httptest.NewRequest("GET", validatorEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}`)
+	})
+
+	t.Run("forbidden with incorrect roles", func(t *testing.T) {
+		req := httptest.NewRequest("GET", forbidenEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusForbidden)
+		assertBody(t, w.Body.String(), "\n")
+	})
+
+	t.Run("ok with param extractor", func(t *testing.T) {
+		req := httptest.NewRequest("GET", registeredEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}`)
+	})
+
+	t.Run("ok with propagate headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+		// Check header-overwrite: it must be overwritten by a claim in the JWT!
+		req.Header.Set("x-krakend-replace", "abc")
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}`)
+		assertPropagationHeaders(t, req)
+	})
+
+	t.Run("ok without token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}`)
+	})
+
+	t.Run("unauthorized with invalid token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+invalidToken)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusUnauthorized)
+		assertBody(t, w.Body.String(), "algorithm is invalid\n")
+	})
+
+	t.Run("ok with valid token at optional endpoint", func(t *testing.T) {
+		req := httptest.NewRequest("GET", optionalEndpointCfg.Endpoint, new(bytes.Buffer))
+		req.Header.Set("Authorization", "BEARER "+token)
+
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+
+		assertStatus(t, w.Code, http.StatusOK)
+		assertBody(t, w.Body.String(), `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}`)
+	})
+}
+
+func jwkEndpoint(name string) http.HandlerFunc {
+	data, err := ioutil.ReadFile("../fixtures/" + name + ".json")
+	return func(rw http.ResponseWriter, _ *http.Request) {
+		if err != nil {
+			rw.WriteHeader(500)
+			return
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		rw.Write(data)
 	}
-	if body := w.Body.String(); body != "\n" {
-		t.Errorf("unexpected body: %s", body)
+}
+
+func dummyParamsExtractor(_ *http.Request) map[string]string {
+	return map[string]string{}
+}
+
+func assertStatus(t testing.TB, got, want int) {
+	t.Helper()
+
+	if got != want {
+		t.Errorf("unexpected status code: %d", got)
 	}
+}
 
-	req = httptest.NewRequest("GET", registeredEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
+func assertBody(t testing.TB, got, want string) {
+	t.Helper()
 
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected status code: %d", w.Code)
+	if got != want {
+		t.Errorf("unexpected body: %s", got)
 	}
-	if body := w.Body.String(); body != `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}` {
-		t.Errorf("unexpected body: %s", body)
-	}
+}
 
-	req = httptest.NewRequest("GET", propagateHeadersEndpointCfg.Endpoint, new(bytes.Buffer))
-	req.Header.Set("Authorization", "BEARER "+token)
-	// Check header-overwrite: it must be overwritten by a claim in the JWT!
-	req.Header.Set("x-krakend-replace", "abc")
-
-	w = httptest.NewRecorder()
-	engine.ServeHTTP(w, req)
-
+func assertPropagationHeaders(t testing.TB, req *http.Request) {
 	if req.Header.Get("x-krakend-jti") == "" {
 		t.Error("JWT claim not propagated to header: jti")
 	} else if req.Header.Get("x-krakend-jti") != "mnb23vcsrt756yuiomnbvcx98ertyuiop" {
@@ -144,27 +213,4 @@ func TestTokenSignatureValidator(t *testing.T) {
 	if req.Header.Get("x-krakend-ne") != "" {
 		t.Error("JWT claim propagated, although it shouldn't: nonexistent")
 	}
-
-	if w.Code != http.StatusOK {
-		t.Errorf("unexpected status code: %d", w.Code)
-	}
-	if body := w.Body.String(); body != `{"aaaa":{"bar":"b","foo":"a"},"bbbb":true,"cccc":1234567890}` {
-		t.Errorf("unexpected body: %s", body)
-	}
-}
-
-func jwkEndpoint(name string) http.HandlerFunc {
-	data, err := ioutil.ReadFile("../fixtures/" + name + ".json")
-	return func(rw http.ResponseWriter, _ *http.Request) {
-		if err != nil {
-			rw.WriteHeader(500)
-			return
-		}
-		rw.Header().Set("Content-Type", "application/json")
-		rw.Write(data)
-	}
-}
-
-func dummyParamsExtractor(_ *http.Request) map[string]string {
-	return map[string]string{}
 }


### PR DESCRIPTION
On some endpoints I need to proxy a request with token and without token. For instance, `GET /basket` can be requested by guests and by authorized users. In order to use it, I added new option `optional` for `auth/validator` middleware.